### PR TITLE
Remove null item checks

### DIFF
--- a/src/ConcurrentHashSet/ConcurrentHashSet.cs
+++ b/src/ConcurrentHashSet/ConcurrentHashSet.cs
@@ -268,8 +268,6 @@ namespace ConcurrentCollections
         /// contains too many items.</exception>
         public bool Add(T item)
         {
-            if (item == null) throw new ArgumentNullException(nameof(item));
-
             return AddInternal(item, _comparer.GetHashCode(item), true);
         }
 
@@ -302,8 +300,6 @@ namespace ConcurrentCollections
         /// <exception cref="T:System.ArgumentNullException"><paramref name="item"/> is a null reference.</exception>
         public bool Contains(T item)
         {
-            if (item == null) throw new ArgumentNullException(nameof(item));
-
             var hashcode = _comparer.GetHashCode(item);
 
             // We must capture the _buckets field in a local variable. It is set to a new table on each table resize.
@@ -335,8 +331,6 @@ namespace ConcurrentCollections
         /// <exception cref="T:System.ArgumentNullException"><paramref name="item"/> is a null reference.</exception>
         public bool TryRemove(T item)
         {
-            if (item == null) throw new ArgumentNullException(nameof(item));
-
             var hashcode = _comparer.GetHashCode(item);
             while (true)
             {


### PR DESCRIPTION
Figured I'd take a stab at #3 in case you agreed it should support null items. It looks like just removing the exception checks is enough. The following test code works fine now:

```
ConcurrentHashSet<string> hs = new ConcurrentHashSet<string>();
hs.Add("test");
hs.Contains("test").Dump(); // true
hs.Contains(null).Dump();  // false
hs.Add(null).Dump();  // true
hs.Add(null).Dump();  // false
hs.Count.Dump(); // 2
hs.Contains(null).Dump();  // true
hs.TryRemove(null).Dump();  // true
hs.Contains(null).Dump();  // false
hs.TryRemove(null).Dump();  // false
hs.Count.Dump(); // 1
```
